### PR TITLE
Fix: Asset not consumable "insufficient tokens"

### DIFF
--- a/src/components/organisms/AssetActions/Compute/FormComputeDataset.tsx
+++ b/src/components/organisms/AssetActions/Compute/FormComputeDataset.tsx
@@ -164,10 +164,11 @@ export default function FormStartCompute({
   ])
 
   useEffect(() => {
-    if (!totalPrice) return
-    setIsBalanceSufficient(
-      compareAsBN(balance.ocean, `${totalPrice}`) || Number(dtBalance) >= 1
-    )
+    if (totalPrice >= 0) {
+      setIsBalanceSufficient(
+        compareAsBN(balance.ocean, `${totalPrice}`) || Number(dtBalance) >= 1
+      )
+    }
   }, [totalPrice])
 
   return (


### PR DESCRIPTION
## Proposed Changes

  - the total price in ctd is now correctly settled when both dataset and algo are free